### PR TITLE
Fix: MASA token may be minted by everyone

### DIFF
--- a/contracts/tokens/MASA.sol
+++ b/contracts/tokens/MASA.sol
@@ -7,8 +7,4 @@ contract MASA is ERC20 {
     constructor() ERC20("$MASA", "$MASA") {
         _mint(msg.sender, 1000000e18);
     }
-
-    function mint() external {
-        _mint(msg.sender, 1000000e18);
-    }
 }


### PR DESCRIPTION
Fixes #69.
This function was added for testing purposes in a fake $MASA token, but it's not used.

┆Issue is synchronized with this [Jira Bug](https://masa-finance.atlassian.net/browse/MAS-503) by [Unito](https://www.unito.io)
