### PR TITLE
Fix: Delete used URI of a SoulName when burning it

### DIFF
--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -202,8 +202,8 @@ contract SoulName is MasaNFT, ISoulName {
         }
 
         if (bytes(_tokenURIs[tokenId]).length != 0) {
-            delete _tokenURIs[tokenId];
             _URIs[_tokenURIs[tokenId]] = false;
+            delete _tokenURIs[tokenId];
         }
 
         super.burn(tokenId);


### PR DESCRIPTION
Fixes #85.
* Delete used URI of a SoulName when burning it