### PR TITLE
Set soulname as default

### DIFF
--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -42,15 +42,15 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
         uint256 tokenId;
     }
 
-    struct DefaultName {
-      bool exists;
-      uint256 tokenId;
+    struct DefaultSoulName {
+        bool exists;
+        uint256 tokenId;
     }
 
     mapping(uint256 => TokenData) public tokenData; // used to store the data of the token id
     mapping(string => NameData) public nameData; // stores the token id of the current active soul name
 
-    mapping(address => DefaultName) private defaultName; // stores the token id of the default soul name
+    mapping(address => DefaultSoulName) private defaultSoulName; // stores the token id of the default soul name
 
     /* ========== INITIALIZE ========== */
 
@@ -215,6 +215,17 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
         }
 
         super.burn(tokenId);
+    }
+
+    /// @notice Sets the default soul name for the owner
+    /// @dev The caller must be the owner of the soul name.
+    /// @param tokenId TokenId of the soul name
+    function setDefaultSoulName(uint256 tokenId) external {
+        address owner = ERC721.ownerOf(tokenId);
+        if (_msgSender() != owner) revert CallerNotOwner(_msgSender());
+
+        defaultSoulName[_msgSender()].tokenId = tokenId;
+        defaultSoulName[_msgSender()].exists = true;
     }
 
     /* ========== VIEWS ========== */

--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -340,11 +340,26 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
         string[] memory _sbtNames = new string[](results);
         uint256 index = 0;
 
-        for (uint256 i = 0; i < balance; i++) {
-            uint256 tokenId = tokenOfOwnerByIndex(owner, i);
+        if (defaultSoulName[owner].exists) {
+            uint256 tokenId = defaultSoulName[owner].tokenId;
             if (tokenData[tokenId].expirationDate >= block.timestamp) {
                 _sbtNames[index] = Utils.toLowerCase(tokenData[tokenId].name);
                 index = index.add(1);
+            }
+        }
+
+        for (uint256 i = 0; i < balance; i++) {
+            uint256 tokenId = tokenOfOwnerByIndex(owner, i);
+            if (
+                !defaultSoulName[owner].exists ||
+                tokenId != defaultSoulName[owner].tokenId
+            ) {
+                if (tokenData[tokenId].expirationDate >= block.timestamp) {
+                    _sbtNames[index] = Utils.toLowerCase(
+                        tokenData[tokenId].name
+                    );
+                    index = index.add(1);
+                }
             }
         }
 

--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -50,7 +50,7 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
     mapping(uint256 => TokenData) public tokenData; // used to store the data of the token id
     mapping(string => NameData) public nameData; // stores the token id of the current active soul name
 
-    mapping(address => DefaultSoulName) private defaultSoulName; // stores the token id of the default soul name
+    mapping(address => DefaultSoulName) public defaultSoulName; // stores the token id of the default soul name
 
     /* ========== INITIALIZE ========== */
 
@@ -365,6 +365,22 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
 
         // return identity names if exists and are active
         return _sbtNames;
+    }
+
+    /// @notice Returns the default soul name of an account
+    /// @dev This function queries the default soul name of the specified account
+    /// @param owner Address of the owner of the identities
+    /// @return Default soul name associated to the account
+    function getDefaultSoulName(
+        address owner
+    ) external view returns (string memory) {
+        if (defaultSoulName[owner].exists) {
+            uint256 tokenId = defaultSoulName[owner].tokenId;
+            if (tokenData[tokenId].expirationDate >= block.timestamp) {
+                return _getName(tokenData[tokenId].name);
+            }
+        }
+        return "";
     }
 
     /// @notice A distinct Uniform Resource Identifier (URI) for a given asset.

--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -373,7 +373,7 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
     /// @return Default soul name associated to the account
     function getDefaultSoulName(
         address owner
-    ) external view returns (string memory) {
+    ) external view override returns (string memory) {
         if (defaultSoulName[owner].exists) {
             uint256 tokenId = defaultSoulName[owner].tokenId;
             if (tokenData[tokenId].expirationDate >= block.timestamp) {

--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -32,9 +32,6 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
     mapping(uint256 => string) private _tokenURIs;
     mapping(string => bool) private _URIs; // used to check if a uri is already used
 
-    mapping(uint256 => TokenData) public tokenData; // used to store the data of the token id
-    mapping(string => NameData) public nameData; // stores the token id of the current active soul name
-
     struct TokenData {
         string name; // Name with lowercase and uppercase
         uint256 expirationDate;
@@ -44,6 +41,16 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
         bool exists;
         uint256 tokenId;
     }
+
+    struct DefaultName {
+      bool exists;
+      uint256 tokenId;
+    }
+
+    mapping(uint256 => TokenData) public tokenData; // used to store the data of the token id
+    mapping(string => NameData) public nameData; // stores the token id of the current active soul name
+
+    mapping(address => DefaultName) private defaultName; // stores the token id of the default soul name
 
     /* ========== INITIALIZE ========== */
 

--- a/contracts/SoulboundIdentity.sol
+++ b/contracts/SoulboundIdentity.sol
@@ -206,6 +206,12 @@ contract SoulboundIdentity is
         return soulName.getSoulNames(tokenId);
     }
 
+    function getDefaultSoulName(
+        address owner
+    ) external view returns (string memory) {
+        return soulName.getDefaultSoulName(owner);
+    }
+
     /* ========== PRIVATE FUNCTIONS ========================================= */
 
     /* ========== MODIFIERS ================================================= */

--- a/contracts/interfaces/ISoulName.sol
+++ b/contracts/interfaces/ISoulName.sol
@@ -38,4 +38,8 @@ interface ISoulName {
     function getSoulNames(
         uint256 identityId
     ) external view returns (string[] memory sbtNames);
+
+    function getDefaultSoulName(
+        address owner
+    ) external view returns (string memory);
 }

--- a/docs/SoulName.md
+++ b/docs/SoulName.md
@@ -116,6 +116,29 @@ function contractURI() external view returns (string)
 |---|---|---|
 | _0 | string | undefined |
 
+### defaultSoulName
+
+```solidity
+function defaultSoulName(address) external view returns (bool exists, uint256 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| exists | bool | undefined |
+| tokenId | uint256 | undefined |
+
 ### exists
 
 ```solidity
@@ -176,6 +199,28 @@ function getApproved(uint256 tokenId) external view returns (address)
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
+
+### getDefaultSoulName
+
+```solidity
+function getDefaultSoulName(address owner) external view returns (string)
+```
+
+Returns the default soul name of an account
+
+*This function queries the default soul name of the specified account*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | Address of the owner of the identities |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | Default soul name associated to the account |
 
 ### getExtension
 
@@ -629,6 +674,22 @@ Sets the URI of the smart contract metadata
 | Name | Type | Description |
 |---|---|---|
 | _contractURI | string | URI of the smart contract metadata |
+
+### setDefaultSoulName
+
+```solidity
+function setDefaultSoulName(uint256 tokenId) external nonpayable
+```
+
+Sets the default soul name for the owner
+
+*The caller must be the owner of the soul name.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | TokenId of the soul name |
 
 ### setExtension
 

--- a/docs/SoulboundIdentity.md
+++ b/docs/SoulboundIdentity.md
@@ -138,6 +138,28 @@ Returns true if the token exists
 |---|---|---|
 | _0 | bool | True if the token exists |
 
+### getDefaultSoulName
+
+```solidity
+function getDefaultSoulName(address owner) external view returns (string)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined |
+
 ### getExtension
 
 ```solidity

--- a/docs/interfaces/ISoulName.md
+++ b/docs/interfaces/ISoulName.md
@@ -10,6 +10,28 @@
 
 ## Methods
 
+### getDefaultSoulName
+
+```solidity
+function getDefaultSoulName(address owner) external view returns (string)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined |
+
 ### getExtension
 
 ```solidity


### PR DESCRIPTION
Let the owners set a soul name as default:
* Add `getDefaultSoulName()` function
* Return the default soul name the first in the return array of `getSoulNames()`