### PR TITLE
Set identity smart contract address optional in SoulName

### DIFF
--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -243,6 +243,7 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
     /// @return tokenId SoulName id of the soul name
     /// @return expirationDate Expiration date of the soul name
     /// @return active `true` if the soul name is active, `false` otherwise
+    /// @return owner Owner of the soul name
     function getTokenData(
         string memory name
     )
@@ -255,7 +256,8 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
             uint256 identityId,
             uint256 tokenId,
             uint256 expirationDate,
-            bool active
+            bool active,
+            address owner
         )
     {
         tokenId = _getTokenId(name);
@@ -275,7 +277,8 @@ contract SoulName is MasaNFT, ISoulName, ReentrancyGuard {
             _identityId,
             tokenId,
             _tokenData.expirationDate,
-            _tokenData.expirationDate >= block.timestamp
+            _tokenData.expirationDate >= block.timestamp,
+            _owner
         );
     }
 

--- a/contracts/SoulboundIdentity.sol
+++ b/contracts/SoulboundIdentity.sol
@@ -161,7 +161,7 @@ contract SoulboundIdentity is
     function ownerOf(
         string memory name
     ) external view soulNameAlreadySet returns (address) {
-        (, , uint256 identityId, , , ) = soulName.getTokenData(name);
+        (, , uint256 identityId, , , , ) = soulName.getTokenData(name);
         return super.ownerOf(identityId);
     }
 
@@ -172,7 +172,7 @@ contract SoulboundIdentity is
     function tokenURI(
         string memory name
     ) external view soulNameAlreadySet returns (string memory) {
-        (, , uint256 identityId, , , ) = soulName.getTokenData(name);
+        (, , uint256 identityId, , , , ) = soulName.getTokenData(name);
         return super.tokenURI(identityId);
     }
 
@@ -214,6 +214,7 @@ contract SoulboundIdentity is
     /// @return tokenId SoulName id of the soul name
     /// @return expirationDate Expiration date of the soul name
     /// @return active `true` if the soul name is active, `false` otherwise
+    /// @return owner Address of the owner of the soul name
     function getTokenData(
         string memory name
     )
@@ -226,7 +227,8 @@ contract SoulboundIdentity is
             uint256 identityId,
             uint256 tokenId,
             uint256 expirationDate,
-            bool active
+            bool active,
+            address owner
         )
     {
         return soulName.getTokenData(name);

--- a/contracts/interfaces/ISoulName.sol
+++ b/contracts/interfaces/ISoulName.sol
@@ -26,7 +26,8 @@ interface ISoulName {
             uint256 identityId,
             uint256 tokenId,
             uint256 expirationDate,
-            bool active
+            bool active,
+            address owner
         );
 
     function getTokenId(string memory name) external view returns (uint256);

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -35,6 +35,7 @@ error ProtocolFeeReceiverNotSet();
 error RefundFailed();
 error SameValue();
 error SBTAlreadyLinked(address token);
+error SoulboundIdentityNotSet();
 error SoulNameContractNotSet();
 error TokenNotFound(uint256 tokenId);
 error TransferFailed();

--- a/docs/SoulName.md
+++ b/docs/SoulName.md
@@ -263,7 +263,7 @@ Returns all the active soul names of an account
 ### getTokenData
 
 ```solidity
-function getTokenData(string name) external view returns (string sbtName, bool linked, uint256 identityId, uint256 tokenId, uint256 expirationDate, bool active)
+function getTokenData(string name) external view returns (string sbtName, bool linked, uint256 identityId, uint256 tokenId, uint256 expirationDate, bool active, address owner)
 ```
 
 Returns the information of a soul name
@@ -286,6 +286,7 @@ Returns the information of a soul name
 | tokenId | uint256 | SoulName id of the soul name |
 | expirationDate | uint256 | Expiration date of the soul name |
 | active | bool | `true` if the soul name is active, `false` otherwise |
+| owner | address | Owner of the soul name |
 
 ### getTokenId
 

--- a/docs/SoulName.md
+++ b/docs/SoulName.md
@@ -1140,6 +1140,17 @@ error SameValue()
 
 
 
+### SoulboundIdentityNotSet
+
+```solidity
+error SoulboundIdentityNotSet()
+```
+
+
+
+
+
+
 ### TokenNotFound
 
 ```solidity
@@ -1171,17 +1182,6 @@ error URIAlreadyExists(string tokenURI)
 | Name | Type | Description |
 |---|---|---|
 | tokenURI | string | undefined |
-
-### ZeroAddress
-
-```solidity
-error ZeroAddress()
-```
-
-
-
-
-
 
 ### ZeroLengthName
 

--- a/docs/SoulboundIdentity.md
+++ b/docs/SoulboundIdentity.md
@@ -396,7 +396,7 @@ Returns all the active soul names of an account
 ### getTokenData
 
 ```solidity
-function getTokenData(string name) external view returns (string sbtName, bool linked, uint256 identityId, uint256 tokenId, uint256 expirationDate, bool active)
+function getTokenData(string name) external view returns (string sbtName, bool linked, uint256 identityId, uint256 tokenId, uint256 expirationDate, bool active, address owner)
 ```
 
 Returns the information of a soul name
@@ -419,6 +419,7 @@ Returns the information of a soul name
 | tokenId | uint256 | SoulName id of the soul name |
 | expirationDate | uint256 | Expiration date of the soul name |
 | active | bool | `true` if the soul name is active, `false` otherwise |
+| owner | address | Address of the owner of the soul name |
 
 ### grantRole
 

--- a/docs/interfaces/ISoulName.md
+++ b/docs/interfaces/ISoulName.md
@@ -74,7 +74,7 @@ function getSoulNames(address owner) external view returns (string[] sbtNames)
 ### getTokenData
 
 ```solidity
-function getTokenData(string name) external view returns (string sbtName, bool linked, uint256 identityId, uint256 tokenId, uint256 expirationDate, bool active)
+function getTokenData(string name) external view returns (string sbtName, bool linked, uint256 identityId, uint256 tokenId, uint256 expirationDate, bool active, address owner)
 ```
 
 
@@ -97,6 +97,7 @@ function getTokenData(string name) external view returns (string sbtName, bool l
 | tokenId | uint256 | undefined |
 | expirationDate | uint256 | undefined |
 | active | bool | undefined |
+| owner | address | undefined |
 
 ### getTokenId
 

--- a/test/SoulboundCreditScore.test.ts
+++ b/test/SoulboundCreditScore.test.ts
@@ -106,7 +106,8 @@ const signMintCreditScoreToAddress = async (
 
 describe("Soulbound Credit Score", () => {
   before(async () => {
-    [, owner, protocolWallet, address1, authority, projectWallet] = await ethers.getSigners();
+    [, owner, protocolWallet, address1, authority, projectWallet] =
+      await ethers.getSigners();
   });
 
   beforeEach(async () => {
@@ -182,9 +183,12 @@ describe("Soulbound Credit Score", () => {
 
   describe("owner and project admin functions", () => {
     beforeEach(async () => {
-      const PROJECT_ADMIN_ROLE = await soulboundCreditScore.PROJECT_ADMIN_ROLE();
+      const PROJECT_ADMIN_ROLE =
+        await soulboundCreditScore.PROJECT_ADMIN_ROLE();
 
-      await soulboundCreditScore.connect(owner).grantRole(PROJECT_ADMIN_ROLE, projectWallet.address);
+      await soulboundCreditScore
+        .connect(owner)
+        .grantRole(PROJECT_ADMIN_ROLE, projectWallet.address);
     });
 
     it("should set SoulboundIdentity from owner", async () => {
@@ -213,7 +217,9 @@ describe("Soulbound Credit Score", () => {
     });
 
     it("should add authority from project admin", async () => {
-      await soulboundCreditScore.connect(projectWallet).addAuthority(address1.address);
+      await soulboundCreditScore
+        .connect(projectWallet)
+        .addAuthority(address1.address);
 
       expect(await soulboundCreditScore.authorities(address1.address)).to.be
         .true;


### PR DESCRIPTION
Made all identity smart contract references as optional from the SoulName.