### PR TITLE
Upgrade to 0.8.8 solc compiler

### DIFF
--- a/contracts/SoulLinker.sol
+++ b/contracts/SoulLinker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";

--- a/contracts/SoulName.sol
+++ b/contracts/SoulName.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";

--- a/contracts/SoulStore.sol
+++ b/contracts/SoulStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/contracts/SoulboundCreditScore.sol
+++ b/contracts/SoulboundCreditScore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 

--- a/contracts/SoulboundGreen.sol
+++ b/contracts/SoulboundGreen.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 

--- a/contracts/SoulboundIdentity.sol
+++ b/contracts/SoulboundIdentity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 

--- a/contracts/dex/PaymentGateway.sol
+++ b/contracts/dex/PaymentGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/interfaces/ILinkableSBT.sol
+++ b/contracts/interfaces/ILinkableSBT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "../tokens/SBT/ISBT.sol";
 

--- a/contracts/interfaces/ISoulName.sol
+++ b/contracts/interfaces/ISoulName.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 interface ISoulName {
     function mint(

--- a/contracts/interfaces/ISoulboundIdentity.sol
+++ b/contracts/interfaces/ISoulboundIdentity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "../tokens/SBT/ISBT.sol";
 

--- a/contracts/interfaces/dex/IUniswapRouter.sol
+++ b/contracts/interfaces/dex/IUniswapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /// @title Uniswap Router interface
 /// @author Masa Finance

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 error AddressDoesNotHaveIdentity(address to);
 error AlreadyAdded();

--- a/contracts/libraries/Utils.sol
+++ b/contracts/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /// @title Utilities library for Masa Contracts Identity repository
 /// @author Masa Finance

--- a/contracts/reference/ReferenceSBTAuthority.sol
+++ b/contracts/reference/ReferenceSBTAuthority.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 

--- a/contracts/reference/ReferenceSBTSelfSovereign.sol
+++ b/contracts/reference/ReferenceSBTSelfSovereign.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 

--- a/contracts/tokens/MasaNFT.sol
+++ b/contracts/tokens/MasaNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/contracts/tokens/MasaSBT.sol
+++ b/contracts/tokens/MasaSBT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 

--- a/contracts/tokens/MasaSBTAuthority.sol
+++ b/contracts/tokens/MasaSBTAuthority.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Counters.sol";
 

--- a/contracts/tokens/MasaSBTSelfSovereign.sol
+++ b/contracts/tokens/MasaSBTSelfSovereign.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/contracts/tokens/SBT/ISBT.sol
+++ b/contracts/tokens/SBT/ISBT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/tokens/SBT/SBT.sol
+++ b/contracts/tokens/SBT/SBT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/utils/Context.sol";

--- a/contracts/tokens/SBT/extensions/ISBTEnumerable.sol
+++ b/contracts/tokens/SBT/extensions/ISBTEnumerable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "../ISBT.sol";
 

--- a/contracts/tokens/SBT/extensions/ISBTMetadata.sol
+++ b/contracts/tokens/SBT/extensions/ISBTMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "../ISBT.sol";
 

--- a/contracts/tokens/SBT/extensions/SBTBurnable.sol
+++ b/contracts/tokens/SBT/extensions/SBTBurnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/Context.sol";
 

--- a/contracts/tokens/SBT/extensions/SBTEnumerable.sol
+++ b/contracts/tokens/SBT/extensions/SBTEnumerable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import "../SBT.sol";
 import "./ISBTEnumerable.sol";

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ export default {
   networks,
 
   solidity: {
-    version: "0.8.7",
+    version: "0.8.8",
     settings: {
       optimizer: {
         enabled: true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docgen": "hardhat dodoc",
     "coverage": "hardhat coverage",
     "deploy:alfajores": "hardhat deploy --network alfajores && yarn addresses",
-    "deploy:basegoerli": "hardhat deploy--network basegoerli && yarn addresses",
+    "deploy:basegoerli": "hardhat deploy --network basegoerli && yarn addresses",
     "deploy:bsc": "hardhat deploy --network bsc && yarn addresses",
     "deploy:bsctest": "hardhat deploy --network bsctest && yarn addresses",
     "deploy:celo": "hardhat deploy --network celo && yarn addresses",


### PR DESCRIPTION
Upgrade to 0.8.8 solc compiler to solve this error:
```
The Solidity version pragma statement in these files doesn't match any of the configured compilers in your config. Change the pragma or configure additional compiler versions in your hardhat config.

  * @openzeppelin/contracts/utils/cryptography/EIP712.sol (^0.8.8)
  * @openzeppelin/contracts/utils/ShortStrings.sol (^0.8.8)
```