### PR TITLE
chore: remove core team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 # For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
 
 # default owners, overridden by package specific owners below
-* @masa-finance/core-team
+* @masa-finance/smart-contracts
 
 # directory and file-level owners. Feel free to add to this!


### PR DESCRIPTION
Replace it with smart-contracts team